### PR TITLE
Use Command status constants in console commands

### DIFF
--- a/app/Console/Commands/AssignSuperAdmin.php
+++ b/app/Console/Commands/AssignSuperAdmin.php
@@ -24,7 +24,7 @@ class AssignSuperAdmin extends Command
         if (! $user) {
             $this->error("❌ User ID {$userId} not found!");
 
-            return 1;
+            return Command::FAILURE;
         }
 
         // Find super admin role
@@ -33,14 +33,14 @@ class AssignSuperAdmin extends Command
             $this->error('❌ Super Admin role not found! Please run seeders first.');
             $this->line('   Run: php artisan db:seed --class=RoleSeeder');
 
-            return 1;
+            return Command::FAILURE;
         }
 
         // Check if user already has super admin role
         if ($user->hasRole('super_admin')) {
             $this->info("ℹ️  {$user->name} ({$user->email}) is already a Super Admin!");
 
-            return 0;
+            return Command::SUCCESS;
         }
 
         // Remove old roles only if --keep-roles is not specified
@@ -64,6 +64,6 @@ class AssignSuperAdmin extends Command
         $currentRoles = $user->fresh()->roles->pluck('display_name')->toArray();
         $this->line('📋 Current roles: '.implode(', ', $currentRoles));
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/app/Console/Commands/TestEmailCommand.php
+++ b/app/Console/Commands/TestEmailCommand.php
@@ -20,7 +20,7 @@ class TestEmailCommand extends Command
         if (! $user) {
             $this->error('User not found');
 
-            return;
+            return Command::FAILURE;
         }
 
         $this->info("Sending test email to: {$user->email}");
@@ -31,6 +31,10 @@ class TestEmailCommand extends Command
             $this->info('🌐 Check Mailhog at: http://localhost:8025');
         } catch (\Exception $e) {
             $this->error('❌ Failed to send email: '.$e->getMessage());
+
+            return Command::FAILURE;
         }
+
+        return Command::SUCCESS;
     }
 }

--- a/app/Console/Commands/UpdateRolePermissions.php
+++ b/app/Console/Commands/UpdateRolePermissions.php
@@ -151,6 +151,6 @@ class UpdateRolePermissions extends Command
 
         $this->info('🎉 Role permissions update completed!');
 
-        return 0;
+        return Command::SUCCESS;
     }
 }


### PR DESCRIPTION
## Summary
- Replace magic integers with `Command::SUCCESS`/`Command::FAILURE` in AssignSuperAdmin
- Add proper success/failure returns to TestEmailCommand
- Return `Command::SUCCESS` in UpdateRolePermissions

## Testing
- `composer test` *(fails: vendor/autoload.php not found)*
- `composer install` *(fails: requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_689d707cc9bc832aa266843e3724e4a5