### PR TITLE
Use sync for role assignments

### DIFF
--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -329,16 +329,16 @@ class UserController extends Controller
             ], 400);
         }
 
-        $user->roles()->detach();
-
-        if ($request->roles) {
-            foreach ($request->roles as $roleId) {
-                $user->roles()->attach($roleId, [
-                    'assigned_at' => now(),
-                    'assigned_by' => auth()->id(),
-                ]);
-            }
-        }
+        $user->roles()->sync(
+            collect($request->roles ?? [])
+                ->mapWithKeys(fn ($roleId) => [
+                    $roleId => [
+                        'assigned_at' => now(),
+                        'assigned_by' => auth()->id(),
+                    ],
+                ])
+                ->toArray()
+        );
 
         return response()->json([
             'success' => true,


### PR DESCRIPTION
## Summary
- Refactor role assignment update to use `sync` with pivot metadata instead of manual detach/attach loop

## Testing
- `composer test` *(fails: require(/workspace/monetro/vendor/autoload.php) failed)*
- `composer install` *(fails: curl error 56 due to GitHub 403 requiring token)*

------
https://chatgpt.com/codex/tasks/task_e_689d924c5138832aba5652edcdede15f