### PR TITLE
refactor: simplify avatar logging

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -173,9 +173,9 @@ class User extends Authenticatable implements MustVerifyEmail
      */
     public function getAvatarUrlAttribute()
     {
-        \Log::info('Getting avatar URL', [
+        \Log::debug('Getting avatar URL', [
             'user_id' => $this->id,
-            'avatar_path' => $this->avatar,
+            'avatar' => basename($this->avatar ?? ''),
         ]);
 
         if ($this->avatar) {
@@ -185,12 +185,11 @@ class User extends Authenticatable implements MustVerifyEmail
             // Check if file exists in storage
             if (Storage::disk('public')->exists($cleanPath)) {
                 $url = asset('storage/' . $cleanPath);
-                \Log::info('Avatar URL generated', ['url' => $url]);
+                \Log::debug('Avatar URL generated', ['url' => $url]);
                 return $url;
             } else {
                 \Log::warning('Avatar file not found', [
-                    'path' => $cleanPath,
-                    'full_path' => storage_path('app/public/' . $cleanPath),
+                    'filename' => basename($cleanPath),
                 ]);
             }
         }


### PR DESCRIPTION
## Summary
- switch avatar URL logging to debug level
- avoid exposing filesystem paths in logs

## Testing
- `composer test` *(fails: Script @php artisan config:clear --ansi handling the test event returned with error code 255)*
- `composer install` *(fails: curl error 56 requiring GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68a001796c4c832a8774cf9da6d5f4a3