### PR TITLE
Cache current time for monthly reports

### DIFF
--- a/app/Services/ReportService.php
+++ b/app/Services/ReportService.php
@@ -70,9 +70,10 @@ class ReportService
 
             // ตรวจสอบ column ที่มีอยู่
             $dateColumn = $this->getDateColumn();
-            
-            $startDate = Carbon::now()->subMonths($months)->startOfMonth();
-            $endDate = Carbon::now()->endOfMonth();
+            $now = Carbon::now();
+
+            $startDate = $now->copy()->subMonths($months)->startOfMonth();
+            $endDate = $now->copy()->endOfMonth();
 
             $results = DB::table('transactions')
                 ->where('user_id', $userId)
@@ -93,7 +94,7 @@ class ReportService
             $netData = [];
 
             for ($i = $months - 1; $i >= 0; $i--) {
-                $month = Carbon::now()->subMonths($i)->format('Y-m');
+                $month = $now->copy()->subMonths($i)->format('Y-m');
                 $monthsArray[] = $month;
                 
                 // หาข้อมูลสำหรับเดือนนี้
@@ -188,8 +189,10 @@ class ReportService
         $expenseData = [];
         $netData = [];
 
+        $now = Carbon::now();
+
         for ($i = $months - 1; $i >= 0; $i--) {
-            $month = Carbon::now()->subMonths($i)->format('Y-m');
+            $month = $now->copy()->subMonths($i)->format('Y-m');
             $monthsArray[] = $month;
             
             // สร้างข้อมูลสุ่มที่สมจริง


### PR DESCRIPTION
## Summary
- Reuse a single `Carbon::now()` instance for monthly report date range and iteration calculations
- Apply the same optimization to sample monthly series generation

## Testing
- ⚠️ `composer test` (missing vendor autoload) 
- ⚠️ `composer install` (failed: GitHub 403 requires token)


------
https://chatgpt.com/codex/tasks/task_e_68a00179a808832a87a94131aceb477b