### PR TITLE
Add transaction creation feature

### DIFF
--- a/app/Http/Controllers/TransactionController.php
+++ b/app/Http/Controllers/TransactionController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\TransactionStoreRequest;
+use App\Models\Transaction;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\View\View;
+
+class TransactionController extends Controller
+{
+    /**
+     * Show the form for creating a new transaction.
+     */
+    public function create(): View
+    {
+        $categoryClass = 'App\\Models\\Category';
+        $categories = class_exists($categoryClass) ? $categoryClass::all() : [];
+
+        return view('transactions.create', [
+            'categories' => $categories,
+        ]);
+    }
+
+    /**
+     * Store a newly created transaction in storage.
+     */
+    public function store(TransactionStoreRequest $request): RedirectResponse
+    {
+        Transaction::create([
+            'user_id' => auth()->id(),
+            'category_id' => $request->input('category_id'),
+            'type' => $request->input('type'),
+            'amount' => $request->input('amount'),
+            'transaction_date' => $request->input('transaction_date'),
+            'note' => $request->input('note'),
+        ]);
+
+        return redirect()->route('dashboard');
+    }
+}

--- a/app/Http/Requests/TransactionStoreRequest.php
+++ b/app/Http/Requests/TransactionStoreRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class TransactionStoreRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'amount' => ['required', 'numeric', 'min:0'],
+            'transaction_date' => ['required', 'date'],
+            'type' => ['required', Rule::in(['income', 'expense'])],
+            'category_id' => ['nullable', 'integer'],
+            'note' => ['nullable', 'string', 'max:255'],
+        ];
+    }
+}

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Transaction extends Model
+{
+    use HasFactory;
+
+    /**
+     * Mass assignable attributes.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'user_id',
+        'category_id',
+        'type',
+        'amount',
+        'transaction_date',
+        'note',
+    ];
+
+    /**
+     * Get the user that owns the transaction.
+     */
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Get the category associated with the transaction, if available.
+     */
+    public function category()
+    {
+        return $this->belongsTo('App\\Models\\Category');
+    }
+}

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -16,6 +16,9 @@
                     <x-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
                         {{ __('Dashboard') }}
                     </x-nav-link>
+                        <x-nav-link :href="route('transactions.create')" :active="request()->routeIs('transactions.*')">
+                            {{ __('Add Transaction') }}
+                        </x-nav-link>
 
                     @if(auth()->user()->hasRole('admin') || auth()->user()->hasRole('super_admin'))
                         <x-nav-link :href="route('admin.dashboard')" :active="request()->routeIs('admin.*')">
@@ -99,6 +102,9 @@
         <div class="pt-2 pb-3 space-y-1">
             <x-responsive-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
                 {{ __('Dashboard') }}
+            </x-responsive-nav-link>
+            <x-responsive-nav-link :href="route('transactions.create')" :active="request()->routeIs('transactions.*')">
+                {{ __('Add Transaction') }}
             </x-responsive-nav-link>
 
             @if(auth()->user()->hasRole('admin') || auth()->user()->hasRole('super_admin'))

--- a/resources/views/transactions/create.blade.php
+++ b/resources/views/transactions/create.blade.php
@@ -1,0 +1,67 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            {{ __('Create Transaction') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900 dark:text-gray-100">
+                    <form method="POST" action="{{ route('transactions.store') }}">
+                        @csrf
+
+                        <div class="mb-4">
+                            <label for="type" class="block text-sm font-medium text-gray-700 dark:text-gray-200">Type</label>
+                            <select name="type" id="type" class="mt-1 block w-full border-gray-300 dark:bg-gray-700 dark:border-gray-600 dark:text-gray-300 rounded-md shadow-sm">
+                                <option value="income" @selected(old('type') === 'income')>{{ __('Income') }}</option>
+                                <option value="expense" @selected(old('type') === 'expense')>{{ __('Expense') }}</option>
+                            </select>
+                            @error('type')<div class="text-sm text-red-600">{{ $message }}</div>@enderror
+                        </div>
+
+                        <div class="mb-4">
+                            <label for="amount" class="block text-sm font-medium text-gray-700 dark:text-gray-200">Amount</label>
+                            <input type="number" step="0.01" name="amount" id="amount" value="{{ old('amount') }}" class="mt-1 block w-full border-gray-300 dark:bg-gray-700 dark:border-gray-600 dark:text-gray-300 rounded-md shadow-sm">
+                            @error('amount')<div class="text-sm text-red-600">{{ $message }}</div>@enderror
+                        </div>
+
+                        <div class="mb-4">
+                            <label for="transaction_date" class="block text-sm font-medium text-gray-700 dark:text-gray-200">Date</label>
+                            <input type="date" name="transaction_date" id="transaction_date" value="{{ old('transaction_date') }}" class="mt-1 block w-full border-gray-300 dark:bg-gray-700 dark:border-gray-600 dark:text-gray-300 rounded-md shadow-sm">
+                            @error('transaction_date')<div class="text-sm text-red-600">{{ $message }}</div>@enderror
+                        </div>
+
+                        <div class="mb-4">
+                            <label for="category_id" class="block text-sm font-medium text-gray-700 dark:text-gray-200">Category</label>
+                            @if(count($categories))
+                                <select name="category_id" id="category_id" class="mt-1 block w-full border-gray-300 dark:bg-gray-700 dark:border-gray-600 dark:text-gray-300 rounded-md shadow-sm">
+                                    <option value="">{{ __('Select category') }}</option>
+                                    @foreach($categories as $category)
+                                        <option value="{{ $category->id }}" @selected(old('category_id') == $category->id)>
+                                            {{ $category->name ?? $category->title ?? $category->id }}
+                                        </option>
+                                    @endforeach
+                                </select>
+                            @else
+                                <input type="number" name="category_id" id="category_id" value="{{ old('category_id') }}" class="mt-1 block w-full border-gray-300 dark:bg-gray-700 dark:border-gray-600 dark:text-gray-300 rounded-md shadow-sm">
+                            @endif
+                            @error('category_id')<div class="text-sm text-red-600">{{ $message }}</div>@enderror
+                        </div>
+
+                        <div class="mb-4">
+                            <label for="note" class="block text-sm font-medium text-gray-700 dark:text-gray-200">Note</label>
+                            <textarea name="note" id="note" class="mt-1 block w-full border-gray-300 dark:bg-gray-700 dark:border-gray-600 dark:text-gray-300 rounded-md shadow-sm">{{ old('note') }}</textarea>
+                            @error('note')<div class="text-sm text-red-600">{{ $message }}</div>@enderror
+                        </div>
+
+                        <div>
+                            <button type="submit" class="px-4 py-2 bg-indigo-600 text-white rounded-md">{{ __('Save') }}</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,7 +6,7 @@ use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\Admin\DashboardController as AdminDashboardController;
 use App\Http\Controllers\Admin\RoleController as AdminRoleController;
 use App\Http\Controllers\Admin\UserController as AdminUserController;
-use App\Http\Controllers\ProfileController;
+use App\Http\Controllers\TransactionController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
@@ -57,6 +57,9 @@ Route::middleware(['auth', 'verified'])->group(function () {
     });
 
     Route::post('/preferences/theme', [DashboardController::class, 'setTheme'])->name('preferences.theme');
+
+    Route::get('/transactions/create', [TransactionController::class, 'create'])->name('transactions.create');
+    Route::post('/transactions', [TransactionController::class, 'store'])->name('transactions.store');
 });
 
 // Debug routes (remove in production)


### PR DESCRIPTION
## Summary
- add Transaction model with user/category relations
- implement TransactionController and request validation
- create transaction creation form, routes, and navigation links

## Testing
- `composer test` *(fails: require /vendor/autoload.php)*
- `composer install` *(fails: requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68a0059b7f54832aa6f5413a9db2b706